### PR TITLE
utilize cookies to retain previously inputted name field

### DIFF
--- a/site/static/home.js
+++ b/site/static/home.js
@@ -166,13 +166,22 @@ function updateTimeoutBar(currentTime, maxTime) {
   }
 }
 
+function getCookie(name) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop().split(';').shift();
+}
+
 function toggleLocationButtons() {
+  const now = new Date();
+  var expirationDate = undefined;
   if (nameInput.value === '') {
     if(locationList.classList.contains('show-buttons')) {
       locationList.classList.remove('show-buttons');
     }
     locationList.classList.add('hide-buttons');
     tooltipText.textContent="Enter your name to begin!";
+    expirationDate = new Date(now.getTime() - 1 * 60 * 60 * 1000); // expired an hour ago; invalidates cookie
   }
   else {
     if(locationList.classList.contains('hide-buttons')) {
@@ -180,9 +189,20 @@ function toggleLocationButtons() {
     }
     locationList.classList.add('show-buttons');
     tooltipText.textContent="Where are you?";
+    expirationDate = new Date(now.getTime() + 2190 * 60 * 60 * 1000); // expires 3 months from submission
   }
+  const expires = "expires=" + expirationDate.toUTCString();
+  document.cookie = `username=${nameInput.value}; expires=${expires}; path=/`;
 }
 nameInput.addEventListener('input',toggleLocationButtons);
+
+const username = getCookie("username")
+if (getCookie("username") != undefined) { 
+  console.log("Cookie found: " + getCookie("username"));
+  nameInput.value = username;
+} else {
+  nameInput.value = ""; // will not work because modern browsers ignore autocomplete=off but one can hope
+}
 toggleLocationButtons();
 
 homePageSetup();

--- a/site/templates/home.tmpl
+++ b/site/templates/home.tmpl
@@ -48,7 +48,7 @@
     <h2 style="text-align:center">
         What is your name?
     </h2>
-    <input class="form-control form-control-lg" type="text" placeholder="Enter Name" id="knock_name_input" style="max-width: 300px; display: block; margin: auto;">
+    <input name="knock_name_input" class="form-control form-control-lg" type="text" autocomplete="off" placeholder="Enter Name" id="knock_name_input" style="max-width: 300px; display: block; margin: auto;">
     <br>
     <h2 id="tooltip-text" style="text-align:center">
         Where are you?


### PR DESCRIPTION
This should work unless in the rare chance that a user that has previously inputted a name has not accessed letmein within the last 3 months but their web browser saves the autofill data, which is extremely unlikely in my opinion but someone is probably going to encounter this for some reason.